### PR TITLE
DSK-20018: Add the CAS manifest file

### DIFF
--- a/Examples/CAS/manifest.json
+++ b/Examples/CAS/manifest.json
@@ -1,0 +1,6 @@
+{
+   "sourceName": "CAS Add-ins",
+   "addins": [
+       "https://scifinder-n.cas.org/chemdraw-addin/chemdraw-addin-metadata.json"
+   ]
+}


### PR DESCRIPTION
This could be a temporary location for the CAS manifest file. It will be hosted on a fixed location under PKI control.
Till then we need to put this manifest at a some location so that the integration with ChemDraw can be tested. This manifest will be auto-loaded by ChemDraw.

@PerkinElmer/chemdraw-desktop-reviewers 