### PR TITLE
DSK-25357: Update copyright end year to 2022

### DIFF
--- a/Examples/ChemDrawOAuthExample/src/App.test.tsx
+++ b/Examples/ChemDrawOAuthExample/src/App.test.tsx
@@ -1,7 +1,7 @@
 //
 // App.test.tsx
 //
-// Copyright © 2019-2021 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
 //
 
 import * as React from "react";

--- a/Examples/ChemDrawOAuthExample/src/common/DropboxAPI.ts
+++ b/Examples/ChemDrawOAuthExample/src/common/DropboxAPI.ts
@@ -1,7 +1,7 @@
 //
 // DropboxAPI.ts
 //
-// Copyright © 2019-2021 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
 //
 
 export default class DropboxAPI {

--- a/Examples/ChemDrawOAuthExample/src/components/App.tsx
+++ b/Examples/ChemDrawOAuthExample/src/components/App.tsx
@@ -1,7 +1,7 @@
 //
 // App.tsx
 //
-// Copyright © 2019-2021 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
 //
 
 import * as React from "react";

--- a/Examples/ChemDrawOAuthExample/src/components/UserInfo.tsx
+++ b/Examples/ChemDrawOAuthExample/src/components/UserInfo.tsx
@@ -1,7 +1,7 @@
 //
 // UserInfo.tsx
 //
-// Copyright © 2019-2021 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
 //
 
 import * as React from "react";

--- a/Examples/ChemDrawOAuthExample/src/index.tsx
+++ b/Examples/ChemDrawOAuthExample/src/index.tsx
@@ -1,7 +1,7 @@
 //
 // index.tsx
 //
-// Copyright © 2019-2021 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
 //
 
 import * as React from 'react';

--- a/Examples/Document Data Importer and Exporter/document-set-and-get-data.js
+++ b/Examples/Document Data Importer and Exporter/document-set-and-get-data.js
@@ -6,7 +6,7 @@
 // The supported data formats are CDXML, CDX encoded as Base64, SMILES, InChI, InChIKey,
 // MolV2000, MolV3000, RXNV2000, RXNV3000, and PNG encoded as Base64.
 //
-// Copyright (c) 2017-2021 PerkinElmer, Inc. All rights reserved.
+// Copyright (c) 2017-2022 PerkinElmer, Inc. All rights reserved.
 
 // ESLint configuration
 /* global ChemDrawAPI, $ */

--- a/Examples/Hello World/hello-world.js
+++ b/Examples/Hello World/hello-world.js
@@ -3,7 +3,7 @@
 //
 // This is a simple example of using ChemDraw JavaScript API.
 //
-// Copyright (c) 2017-2021 PerkinElmer, Inc. All rights reserved.
+// Copyright (c) 2017-2022 PerkinElmer, Inc. All rights reserved.
 
 // ESLint configuration
 /* global ChemDrawAPI */

--- a/Examples/Selection Monitor/selection-monitor.js
+++ b/Examples/Selection Monitor/selection-monitor.js
@@ -3,7 +3,7 @@
 //
 // This is an example of using ChemDraw Add-in API to get the selection in a document.
 //
-// Copyright (c) 2018-2021 PerkinElmer, Inc. All rights reserved.
+// Copyright (c) 2018-2022 PerkinElmer, Inc. All rights reserved.
 
 // ESLint configuration
 /* global ChemDrawAPI */

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2018-2021, PerkinElmer, Inc.
+Copyright (c) 2018-2022, PerkinElmer, Inc.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without


### PR DESCRIPTION

These changes update the copyright year range end date to 2022 in user viewable areas.

Related PRs:
https://github.com/PerkinElmer/ChemDraw-CommonCS/pull/1630
https://github.com/PerkinElmer/ChemDraw-Build/pull/312
https://github.com/PerkinElmer/ChemDraw-Chem3D/pull/68
https://github.com/PerkinElmer/ChemDraw-ChemScript/pull/36

@PerkinElmer/chemdraw-desktop-reviewers, @PerkinElmer/corechemistry please review.