### PR TITLE
DSK-28615: Update copyright end year to 2023

### DIFF
--- a/Examples/ChemDrawOAuthExample/src/App.test.tsx
+++ b/Examples/ChemDrawOAuthExample/src/App.test.tsx
@@ -1,7 +1,7 @@
 //
 // App.test.tsx
 //
-// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2023 PerkinElmer, Inc. All rights reserved.
 //
 
 import * as React from "react";

--- a/Examples/ChemDrawOAuthExample/src/common/DropboxAPI.ts
+++ b/Examples/ChemDrawOAuthExample/src/common/DropboxAPI.ts
@@ -1,7 +1,7 @@
 //
 // DropboxAPI.ts
 //
-// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2023 PerkinElmer, Inc. All rights reserved.
 //
 
 export default class DropboxAPI {

--- a/Examples/ChemDrawOAuthExample/src/components/App.tsx
+++ b/Examples/ChemDrawOAuthExample/src/components/App.tsx
@@ -1,7 +1,7 @@
 //
 // App.tsx
 //
-// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2023 PerkinElmer, Inc. All rights reserved.
 //
 
 import * as React from "react";

--- a/Examples/ChemDrawOAuthExample/src/components/UserInfo.tsx
+++ b/Examples/ChemDrawOAuthExample/src/components/UserInfo.tsx
@@ -1,7 +1,7 @@
 //
 // UserInfo.tsx
 //
-// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2023 PerkinElmer, Inc. All rights reserved.
 //
 
 import * as React from "react";

--- a/Examples/ChemDrawOAuthExample/src/index.tsx
+++ b/Examples/ChemDrawOAuthExample/src/index.tsx
@@ -1,7 +1,7 @@
 //
 // index.tsx
 //
-// Copyright © 2019-2022 PerkinElmer, Inc. All rights reserved.
+// Copyright © 2019-2023 PerkinElmer, Inc. All rights reserved.
 //
 
 import * as React from 'react';

--- a/Examples/Document Data Importer and Exporter/document-set-and-get-data.js
+++ b/Examples/Document Data Importer and Exporter/document-set-and-get-data.js
@@ -6,7 +6,7 @@
 // The supported data formats are CDXML, CDX encoded as Base64, SMILES, InChI, InChIKey,
 // MolV2000, MolV3000, RXNV2000, RXNV3000, and PNG encoded as Base64.
 //
-// Copyright (c) 2017-2022 PerkinElmer, Inc. All rights reserved.
+// Copyright (c) 2017-2023 PerkinElmer, Inc. All rights reserved.
 
 // ESLint configuration
 /* global ChemDrawAPI, $ */
@@ -41,7 +41,7 @@ $(function() {
             }));
             break;
 
-        case 'png-scaled-150': 
+        case 'png-scaled-150':
             // Set all PNG options
             setImage(ChemDrawAPI.activeDocument.getPNGBase64Encoded({
                 transparent: true,
@@ -50,7 +50,7 @@ $(function() {
             }));
             break;
 
-        case 'png-scaled-75': 
+        case 'png-scaled-75':
             // Setting only scalePercent and other options get the default value (transparent: true, borderSizeInPixels: 0)
             setImage(ChemDrawAPI.activeDocument.getPNGBase64Encoded({
                 scalePercent: 75
@@ -75,7 +75,7 @@ $(function() {
 
         default:
             alert('Getting PNG image with the selected settings is not supported');
-        } 
+        }
     }
 
     function addData() {

--- a/Examples/Hello World/hello-world.js
+++ b/Examples/Hello World/hello-world.js
@@ -3,7 +3,7 @@
 //
 // This is a simple example of using ChemDraw JavaScript API.
 //
-// Copyright (c) 2017-2022 PerkinElmer, Inc. All rights reserved.
+// Copyright (c) 2017-2023 PerkinElmer, Inc. All rights reserved.
 
 // ESLint configuration
 /* global ChemDrawAPI */

--- a/Examples/Selection Monitor/selection-monitor.js
+++ b/Examples/Selection Monitor/selection-monitor.js
@@ -3,7 +3,7 @@
 //
 // This is an example of using ChemDraw Add-in API to get the selection in a document.
 //
-// Copyright (c) 2018-2022 PerkinElmer, Inc. All rights reserved.
+// Copyright (c) 2018-2023 PerkinElmer, Inc. All rights reserved.
 
 // ESLint configuration
 /* global ChemDrawAPI */


### PR DESCRIPTION
These changes update the copyright year range end date to 2023 in user viewable areas.
See also:
https://github.com/PerkinElmer/ChemDraw-CommonCS/pull/1902
https://github.com/PerkinElmer/ChemDraw-Build/pull/416
https://github.com/PerkinElmer/ChemDraw-Chem3D/pull/92
https://github.com/PerkinElmer/ChemDraw-ChemScript/pull/53
https://github.com/PerkinElmer/chemdraw-web-clipboard/pull/137

@PerkinElmer/chemdraw-desktop-reviewers - please review